### PR TITLE
fix: enforce habit ownership and validate route params

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -138,3 +138,5 @@ dist
 # SvelteKit build / generate output
 .svelte-kit
 
+# Miscellaneous
+audits

--- a/backend/controllers/habitController.js
+++ b/backend/controllers/habitController.js
@@ -32,7 +32,7 @@ export const getHabits = async (req, res) => {
         ...habit.toObject(),
         completedToday: !!log,
       };
-    })
+    }),
   );
 
   res.json(habitsWithStatus);
@@ -43,7 +43,11 @@ const calculateStreak = async (habitId) => {
   let checkDate = new Date();
 
   let todayStr = checkDate.toISOString().split("T")[0];
-  let log = await HabitLog.findOne({ habitId, date: todayStr, completed: true });
+  let log = await HabitLog.findOne({
+    habitId,
+    date: todayStr,
+    completed: true,
+  });
 
   if (log) {
     while (log) {
@@ -69,11 +73,18 @@ const calculateStreak = async (habitId) => {
 export const toggleHabit = async (req, res) => {
   const userId = req.auth.userId;
   const { id } = req.params;
+  const habit = await Habit.findOne({ _id: id, userId });
+
+  if (!habit) {
+    res.status(404);
+    throw new Error("Habit not found");
+  }
 
   const today = new Date().toISOString().split("T")[0];
 
   let log = await HabitLog.findOne({
-    habitId: id,
+    habitId: habit._id,
+    userId,
     date: today,
   });
 
@@ -83,7 +94,7 @@ export const toggleHabit = async (req, res) => {
   } else {
     try {
       log = await HabitLog.create({
-        habitId: id,
+        habitId: habit._id,
         userId,
         date: today,
         completed: true,
@@ -97,15 +108,18 @@ export const toggleHabit = async (req, res) => {
     }
   }
 
-  const newStreak = await calculateStreak(id);
-  await Habit.findByIdAndUpdate(id, { streak: newStreak });
+  const newStreak = await calculateStreak(habit._id);
+  habit.streak = newStreak;
+  await habit.save();
 
   res.json({ ...log.toObject(), streak: newStreak });
 };
 
 export const getUserStats = async (req, res) => {
   const userId = req.auth.userId;
-  const logs = await HabitLog.find({ userId, completed: true }).sort({ date: -1 });
+  const logs = await HabitLog.find({ userId, completed: true }).sort({
+    date: -1,
+  });
 
   if (logs.length === 0) {
     return res.json({ currentMomentum: 0, personalRecord: 0 });
@@ -127,7 +141,9 @@ export const getUserStats = async (req, res) => {
     if (i < uniqueDates.length - 1) {
       const currentDate = new Date(uniqueDates[i]);
       const nextDate = new Date(uniqueDates[i + 1]);
-      const diffInDays = Math.round((currentDate - nextDate) / (1000 * 60 * 60 * 24));
+      const diffInDays = Math.round(
+        (currentDate - nextDate) / (1000 * 60 * 60 * 24),
+      );
 
       if (diffInDays === 1) {
       } else {

--- a/backend/routes/habitRoutes.js
+++ b/backend/routes/habitRoutes.js
@@ -1,7 +1,10 @@
 import express from "express";
 import { requireAuth } from "../middleware/authMiddleware.js";
 import { validate } from "../middleware/validateResource.js";
-import { createHabitSchema } from "../validations/habitValidation.js";
+import {
+  createHabitSchema,
+  habitIdParamsSchema,
+} from "../validations/habitValidation.js";
 import {
   createHabit,
   getHabits,
@@ -14,6 +17,11 @@ const router = express.Router();
 router.post("/", requireAuth, validate(createHabitSchema), createHabit);
 router.get("/", requireAuth, getHabits);
 router.get("/stats", requireAuth, getUserStats);
-router.post("/:id/toggle", requireAuth, toggleHabit);
+router.post(
+  "/:id/toggle",
+  requireAuth,
+  validate(habitIdParamsSchema),
+  toggleHabit,
+);
 
 export default router;

--- a/backend/validations/habitValidation.js
+++ b/backend/validations/habitValidation.js
@@ -1,11 +1,21 @@
+import mongoose from "mongoose";
 import { z } from "zod";
 
 export const createHabitSchema = z.object({
   body: z.object({
-    title: z.string({ required_error: "Habit title is required" })
+    title: z
+      .string({ required_error: "Habit title is required" })
       .min(3, "Title must be at least 3 characters")
       .max(50, "Title cannot exceed 50 characters"),
     frequency: z.enum(["daily", "weekly"]).optional(),
-    goal: z.number().positive().optional()
-  })
+    goal: z.number().positive().optional(),
+  }),
+});
+
+export const habitIdParamsSchema = z.object({
+  params: z.object({
+    id: z.string().refine(mongoose.isValidObjectId, {
+      message: "Invalid habit id",
+    }),
+  }),
 });


### PR DESCRIPTION
## Summary

This PR secures the habit toggle route by enforcing habit ownership and validating the habit route parameter before the controller runs.

Previously, the toggle route did not strictly ensure that the requested habit belonged to the authenticated user. It also allowed invalid habit IDs to reach the controller/Mongoose layer.

## Changes Made

- Added `habitIdParamsSchema` to validate the `id` route parameter
- Applied validation middleware to `POST /:id/toggle`
- Updated habit lookup to use both `_id` and authenticated `userId`
- Ensured habit logs are created or updated with the authenticated `userId`
- Returned `404 Habit not found` when the habit does not exist or does not belong to the user

## Testing

- Verified that a user can toggle their own habit
- Verified that another user's habit cannot be toggled
- Verified that invalid habit IDs are rejected before reaching the controller

Closes #5